### PR TITLE
Autorelease Pools for Darwin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ sudo: required
 dist: trusty
 osx_image: xcode8
 install:
-  - eval "$(curl -sL https://raw.githubusercontent.com/Zewo/Zewo/5254525d9da56df29346fd76e99529c22034d61d/Scripts/install-swiftenv.sh)"
+  - eval "$(curl -sL https://raw.githubusercontent.com/Zewo/Zewo/master/Scripts/Travis/install.sh)"
 script:
   - swift build
   - swift build --configuration release
-  - swift test

--- a/Sources/cr.c
+++ b/Sources/cr.c
@@ -83,7 +83,7 @@ void goprepare(int count, size_t stack_size) {
 #ifdef __APPLE__
     darwin_pool();
 #endif
-    
+
     if(mill_slow(mill_hascrs())) {errno = EAGAIN; return;}
     /* Allocate any resources needed by the polling mechanism. */
     mill_poller_init();
@@ -109,18 +109,18 @@ int mill_suspend(void) {
     if(mill_running && mill_setjmp(&mill_running->ctx))
         return mill_running->result;
     while(1) {
-       /* If there's a coroutine ready to be executed go for it. */
-       if(!mill_slist_empty(&mill_ready)) {
-           ++counter;
-           struct mill_slist_item *it = mill_slist_pop(&mill_ready);
-           mill_running = mill_cont(it, struct mill_cr, ready);
-           mill_jmp(&mill_running->ctx);
-       }
-       /*  Otherwise, we are going to wait for sleeping coroutines
-           and for external events. */
-       mill_wait(1);
-       mill_assert(!mill_slist_empty(&mill_ready));
-       counter = 0;
+        /* If there's a coroutine ready to be executed go for it. */
+        if(!mill_slist_empty(&mill_ready)) {
+            ++counter;
+            struct mill_slist_item *it = mill_slist_pop(&mill_ready);
+            mill_running = mill_cont(it, struct mill_cr, ready);
+            mill_jmp(&mill_running->ctx);
+        }
+        /*  Otherwise, we are going to wait for sleeping coroutines
+            and for external events. */
+        mill_wait(1);
+        mill_assert(!mill_slist_empty(&mill_ready));
+        counter = 0;
     }
 }
 
@@ -140,7 +140,7 @@ void *mill_go_prologue(const char *created) {
 #ifdef __APPLE__
     darwin_pool();
 #endif
-    
+
     /* Ensure that debug functions are available whenever a single go()
      statement is present in the user's code. */
     mill_preserve_debug();
@@ -161,7 +161,7 @@ void mill_go_epilogue(void) {
 #ifdef __APPLE__
     darwin_pool();
 #endif
-    
+
     mill_trace(NULL, "go() done");
     mill_unregister_cr(&mill_running->debug);
     mill_freestack(mill_running + 1);
@@ -175,7 +175,7 @@ void mill_yield(const char *current) {
 #ifdef __APPLE__
     darwin_pool();
 #endif
-    
+
     mill_trace(current, "yield()");
     mill_set_current(&mill_running->debug, current);
     /* This looks fishy, but yes, we can resume the coroutine even before

--- a/Sources/cr.c
+++ b/Sources/cr.c
@@ -55,7 +55,7 @@ void darwin_prepare() {
         sel_getUid_fptr = dlsym(handle, "sel_getUid");
         darwin_prepared = 1;
     }
-    
+
     if (!darwin_prepared) {
         printf("libmill failed to prepare for Darwin platform.");
         mill_assert(0);
@@ -92,7 +92,7 @@ int mill_suspend(void) {
 #ifdef __APPLE__
     darwin_pool();
 #endif
-    
+
     /* Even if process never gets idle, we have to process external events
        once in a while. The external signal may very well be a deadline or
        a user-issued command that cancels the CPU intensive operation. */
@@ -105,18 +105,18 @@ int mill_suspend(void) {
     if(mill_running && mill_setjmp(&mill_running->ctx))
         return mill_running->result;
     while(1) {
-            /* If there's a coroutine ready to be executed go for it. */
-            if(!mill_slist_empty(&mill_ready)) {
-                ++counter;
-                struct mill_slist_item *it = mill_slist_pop(&mill_ready);
-                mill_running = mill_cont(it, struct mill_cr, ready);
-                mill_jmp(&mill_running->ctx);
-            }
-            /*  Otherwise, we are going to wait for sleeping coroutines
-                and for external events. */
-            mill_wait(1);
-            mill_assert(!mill_slist_empty(&mill_ready));
-            counter = 0;
+       /* If there's a coroutine ready to be executed go for it. */
+       if(!mill_slist_empty(&mill_ready)) {
+           ++counter;
+           struct mill_slist_item *it = mill_slist_pop(&mill_ready);
+           mill_running = mill_cont(it, struct mill_cr, ready);
+           mill_jmp(&mill_running->ctx);
+       }
+       /*  Otherwise, we are going to wait for sleeping coroutines
+           and for external events. */
+       mill_wait(1);
+       mill_assert(!mill_slist_empty(&mill_ready));
+       counter = 0;
     }
 }
 
@@ -124,7 +124,7 @@ void mill_resume(struct mill_cr *cr, int result) {
 #ifdef __APPLE__
     darwin_pool();
 #endif
-    
+
     cr->result = result;
     cr->state = MILL_READY;
     mill_slist_push_back(&mill_ready, &cr->ready);
@@ -172,7 +172,7 @@ void co(void* ctx, void (*routine)(void*), const char *created) {
 #ifdef __APPLE__
     darwin_pool();
 #endif
-    
+
     void *mill_sp = mill_go_prologue(created);
     if(mill_sp) {
         int mill_anchor[mill_unoptimisable1];


### PR DESCRIPTION
This PR adds autorelease pool support on Darwin to avoid massive memory leaks where Foundation objects are not caught in a pool.

Because we cannot have `.m` files on Linux we can't use Objective-C API even if it's wrapped in platform macros.

This patch essentially implements the autorelease pool by draining any existing pool and allocating a new one on entry into `mill_suspend`, `mill_resume` and `co`.

The Objective-C implementation looks like:

```
[autoreleasePool drain];
autoreleasePool = [[NSAutoreleasePool alloc] init];
```
